### PR TITLE
update docker pull command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [TinkerGraph configuration section](http://tinkerpop.apache.org/docs/cur
 
 Alternatively, you can pull the image from DockerHub [here](https://hub.docker.com/r/bricaud/gremlin-server-with-demo-graph/)
 ```
-docker pull bricaud/gremlin-server-rest
+docker pull bricaud/gremlin-server-with-demo-graph
 ```
 .
 


### PR DESCRIPTION
This small PR updates the `docker pull` command in the dev docs to match what I presume to be the new name of the docker image on docker hub https://hub.docker.com/r/bricaud/gremlin-server-with-demo-graph/ 

😄 
